### PR TITLE
Cambio de Strings en Mi Cloud

### DIFF
--- a/Spanish/main/CloudService.apk/res/values-es/strings.xml
+++ b/Spanish/main/CloudService.apk/res/values-es/strings.xml
@@ -120,7 +120,7 @@ Si cambia de tarjeta SIM, se le enviará automáticamente otro SMS para reactiva
      <string name="master_alert_notif_content">%d datos no sincronizaron.</string>
      <string name="master_alert_notif_dspt_add">%s elementos esperando sincronizar</string>
      <string name="master_alert_notif_dspt_no">Sincronizado</string>
-     <string name="master_alert_notif_title">Encender MiCloud</string>
+     <string name="master_alert_notif_title">Activar MiCloud</string>
      <string name="micloud_all_sub_1_intl_sms">Su operador puede cobrarle un SMS internacional para activar este servicio. Su operador le cobrará.</string>
      <string name="micloud_all_sub_1_sms">Se enviará un SMS para activar su tarjeta SIM. Su operador le cobrará.</string>
      <string name="micloud_all_sub_1_sms_1_intl_sms">Se enviarán 2 SMS (nacional e internacional) para activar su tarjeta SIM. Su operador le cobrará.</string>
@@ -401,7 +401,7 @@ Esta función encripta y envía el ID del dispositivo a los servidores de MI."</
      <string name="soundrecorder_sync_records">Sincronización con Mi Cloud</string>
      <string name="start_micloud">Empezar</string>
      <string name="storage">Almacenamiento</string>
-     <string name="sub_alert_notif_content">Encender Micloud</string>
+     <string name="sub_alert_notif_content">Activar Micloud</string>
      <string name="sub_alert_notif_dspt_add">%s elementos esperando sincronizar</string>
      <string name="sub_alert_notif_dspt_no">Sincronizado</string>
      <string name="sub_alert_notif_title">Sincronización con Mi Cloud</string>

--- a/Spanish/main/CloudService.apk/res/values-es/strings.xml
+++ b/Spanish/main/CloudService.apk/res/values-es/strings.xml
@@ -404,7 +404,7 @@ Esta función encripta y envía el ID del dispositivo a los servidores de MI."</
      <string name="sub_alert_notif_content">Encender Micloud</string>
      <string name="sub_alert_notif_dspt_add">%s elementos esperando sincronizar</string>
      <string name="sub_alert_notif_dspt_no">Sincronizado</string>
-     <string name="sub_alert_notif_title">Sincronizado con Mi Cloud</string>
+     <string name="sub_alert_notif_title">Sincronización con Mi Cloud</string>
      <string name="sub_sync_item_sms_summary">Solo sincronizar mensajes que contengan fotos, audio u otros archivos multimedia cuando esté conectado a una red Wi-Fi</string>
      <string name="sub_sync_item_sms_title_wifi_only">Solo sincronizar MMS por Wi-Fi</string>
      <string name="success_upgraded_space">%s añadido</string>


### PR DESCRIPTION
La notificación que salta a veces pone "Sincronizado con Mi Cloud" y debajo "Encender". Quizás fuera mejor que pusiese "Sincronización con mi Mi Cloud" o simplemente "Sincronizar con mi Cloud" y debajo "Activar".