### PR TITLE
Quitado un espacio que sobra y cambiado COMENZATLS por STARTTLS

### DIFF
--- a/Spanish/main/Email.apk/res/values-es/strings.xml
+++ b/Spanish/main/Email.apk/res/values-es/strings.xml
@@ -109,7 +109,9 @@
      <string name="account_setup_incoming_port_label">Puerto</string>
      <string name="account_setup_incoming_security_label">Tipo de seguridad</string>
      <string name="account_setup_incoming_security_none_label">Ninguno</string>
+     <string name="account_setup_incoming_security_ssl_label">SSL/TLS</string>
      <string name="account_setup_incoming_security_ssl_trust_certificates_label">SSL/TLS (aceptar todos los certificados)</string>
+     <string name="account_setup_incoming_security_tls_label">STARTTLS</string>
      <string name="account_setup_incoming_security_tls_trust_certificates_label">STARTTLS (aceptar todos los certificados)</string>
      <string name="account_setup_incoming_server_label">Servidor</string>
      <string name="account_setup_incoming_username_label">Nombre de usuario</string>

--- a/Spanish/main/Email.apk/res/values-es/strings.xml
+++ b/Spanish/main/Email.apk/res/values-es/strings.xml
@@ -110,7 +110,7 @@
      <string name="account_setup_incoming_security_label">Tipo de seguridad</string>
      <string name="account_setup_incoming_security_none_label">Ninguno</string>
      <string name="account_setup_incoming_security_ssl_trust_certificates_label">SSL/TLS (aceptar todos los certificados)</string>
-     <string name="account_setup_incoming_security_tls_trust_certificates_label">COMENZATTLS (aceptar todos los certificados)</string>
+     <string name="account_setup_incoming_security_tls_trust_certificates_label">STARTTLS (aceptar todos los certificados)</string>
      <string name="account_setup_incoming_server_label">Servidor</string>
      <string name="account_setup_incoming_username_label">Nombre de usuario</string>
      <string name="account_setup_incoming_username_label_default_hint">Puede incluir el dominio</string>
@@ -768,7 +768,7 @@
      <string name="ser_resp_err_map_or">%1$s o %2$s</string>
      <string name="ser_resp_err_map_pserr">Nombre de usuario o contraseña incorrecta</string>
      <string name="ser_resp_err_map_serclosed">Servidor %s cerrado</string>
-     <string name="ser_resp_err_map_ssl">"Por favor, intente elegir ' SSL/TLS (aceptar todos los certificados)' en 'Tipo de seguridad'"</string>
+     <string name="ser_resp_err_map_ssl">"Por favor, intente elegir 'SSL/TLS (aceptar todos los certificados)' en 'Tipo de seguridad'"</string>
      <string name="set_network">Definir red</string>
      <string name="setting_default_lable"></string>
      <string name="settings_activity_title">Ajustes</string>


### PR DESCRIPTION
STARTTLS es una opción, si se pone como COMENZATLS nadie va a entender qué es puesto que todas las instrucciones de configuración lo ponen como STARTTLS. He añadido además los dos String que faltan, uno para STARTTLS y el otro para SSL/TLS

Además he quitado un espacio que sobraba.