### PR TITLE
Registro de llamadas

### DIFF
--- a/Spanish/main/TeleService.apk/res/values-es/arrays.xml
+++ b/Spanish/main/TeleService.apk/res/values-es/arrays.xml
@@ -16,7 +16,7 @@
         <item>Hebreo</item>
     </string-array>
     <string-array name="cdma_system_select_choices">
-        <item>En casa sólo</item>
+        <item>Solo en casa</item>
         <item>Automático</item>
     </string-array>
 </resources>

--- a/Spanish/main/YellowPage.apk/res/values-es/strings.xml
+++ b/Spanish/main/YellowPage.apk/res/values-es/strings.xml
@@ -31,10 +31,10 @@
   <string name="callNoAnswerTimeFormat">Ha sonado %s veces</string>
   <string name="callrecordview_item_newcontact">Nuevo contacto</string>
   <string name="callrecordview_item_op_time_minutes_seconds">%1$d min %2$d seg</string>
-  <string name="callrecordview_item_op_time_missed">No conectado</string>
+  <string name="callrecordview_item_op_time_missed">Llamada perdida</string>
   <string name="callrecordview_item_op_time_only_minutes">%d min</string>
   <string name="callrecordview_item_op_time_only_seconds">%d seg</string>
-  <string name="callrecordview_item_op_time_rejected">Rechazado</string>
+  <string name="callrecordview_item_op_time_rejected">Rechazada</string>
   <string name="callrecordview_item_op_time_short_incoming">"Entrante: "</string>
   <string name="callrecordview_item_op_time_short_outgoing">"Saliente: "</string>
   <string name="check_network">Configuración de red</string>


### PR DESCRIPTION
En mi teléfono ahora mismo cuando no contestas la llamada sale "No conectar", aunque el texto de aquí ponía no conectado, el término que se suele usar es llamada perdida.
Rechazado lo he cambiado porque se refiere a la llamada y sería femenino.
Los "sólo" de solamente ya no llevan tilde en castellano: http://www.rae.es/consultas/el-adverbio-solo-y-los-pronombres-demostrativos-sin-tilde